### PR TITLE
Updating version of Jackson because of an error: NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jackson.version>2.7.0</jackson.version>
+		<jackson.version>2.8.7</jackson.version>
 		<junit.version>4.12</junit.version>
 	</properties>
 	<dependencies>


### PR DESCRIPTION
Hi. Your library uses 2.7.0 of Jackson. So I get an error between your library and [java library for bots](https://github.com/rubenlagus/TelegramBots) where is the version of Jackson 2.8.7: 
```
Exception in thread "main" java.lang.NoSuchMethodError: com.fasterxml.jackson.core.JsonGenerator.writeStartObject(Ljava/lang/Object;)V
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:151)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:292)
	at com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:3681)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3057)
	at org.telegram.telegrambots.bots.DefaultAbsSender.sendMethodRequest(DefaultAbsSender.java:709)
	at org.telegram.telegrambots.bots.DefaultAbsSender.sendApiMethod(DefaultAbsSender.java:665)
	at org.telegram.telegrambots.meta.bots.AbsSender.execute(AbsSender.java:47)
	at org.telegram.telegrambots.util.WebhookUtils.clearWebhook(WebhookUtils.java:74)
	at org.telegram.telegrambots.bots.TelegramLongPollingBot.clearWebhook(TelegramLongPollingBot.java:25)
	at org.telegram.telegrambots.meta.TelegramBotsApi.registerBot(TelegramBotsApi.java:120)
	at project.Main.main(Main.java:28)
```
but when I specify explicitly in my own POM file version 2.7.0 (it's your) or 2.8.7 (in lib of bots), all is ok.
So I suggest you to update your version of Jackson to get competible with other libs.

To solved an exception I added: 

`<jackson.version>2.8.7</jackson.version>` in properties (here can  be also your 2.7.0)

And as dependency:
  
```
<dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
      <version>${jackson.version}</version>
</dependency>
```

