### PR TITLE
https in javadoc.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ emoji4j
 [![Coverage Status](https://img.shields.io/coveralls/kcthota/emoji4j/master.svg)](https://coveralls.io/r/kcthota/emoji4j?branch=master)
 [![Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/badge/Maven-Central-blue.svg)](https://maven-badges.herokuapp.com/maven-central/com.kcthota/emoji4j)
-[![Java Doc](https://img.shields.io/badge/JavaDoc-5.0-brightgreen.svg)](http://www.javadoc.io/doc/com.kcthota/emoji4j)
+[![Java Doc](https://img.shields.io/badge/JavaDoc-5.0-brightgreen.svg)](https://www.javadoc.io/doc/com.kcthota/emoji4j)
 
 
 Java library to convert short codes, html entities to emojis and vice-versa. Also supports parsing emoticons, surrogate html entities.


### PR DESCRIPTION
This PR changes the link to the javadoc.io badge in the README.md to use https instead of http.