### PR TITLE
Add option to ignore emoticons

### DIFF
--- a/src/main/java/emoji4j/EmojiUtils.java
+++ b/src/main/java/emoji4j/EmojiUtils.java
@@ -57,7 +57,7 @@ public class EmojiUtils extends AbstractEmoji {
 	 * @return is emoji
 	 */
 	public static boolean isEmoji(String code) {
-		return getEmoji(code) == null ? false : true;
+		return getEmoji(code) != null;
 	}
 
 	/**
@@ -67,18 +67,25 @@ public class EmojiUtils extends AbstractEmoji {
 	 * @return emojified String
 	 */
 	public static String emojify(String text) {
-		return emojify(text, 0);
+		return emojify(text, 0, false);
 		
 	}
+
+	public static String emojify(String text, boolean ignoreEmoticon) {
+		return emojify(text, 0, ignoreEmoticon);
+
+	}
 	
-	private static String emojify(String text, int startIndex) {
+	private static String emojify(String text, int startIndex, boolean ignoreEmoticon) {
 		text = processStringWithRegex(text, shortCodeOrHtmlEntityPattern, startIndex, true);
 		
 		// emotions should be processed in second go.
 		// this will avoid conflicts with shortcodes. For Example: :p:p should
 		// not
 		// be processed as shortcode, but as emoticon
-		text = processStringWithRegex(text, EmojiManager.getEmoticonRegexPattern(), startIndex, true);
+		if (!ignoreEmoticon) {
+			text = processStringWithRegex(text, EmojiManager.getEmoticonRegexPattern(), startIndex, true);
+		}
 
 		return text;
 	}
@@ -146,7 +153,7 @@ public class EmojiUtils extends AbstractEmoji {
 		//do not recurse emojify when coming here through htmlSurrogateEntityPattern2..so we get a chance to check if the tail
 		//is part of a surrogate entity
 		if(recurseEmojify && resetIndex > 0) {
-			return emojify(sb.toString(), resetIndex);
+			return emojify(sb.toString(), resetIndex, false);
 		}
 		return sb.toString();
 	}
@@ -211,7 +218,11 @@ public class EmojiUtils extends AbstractEmoji {
 	 * @return shortcodified string
 	 */
 	public static String shortCodify(String text) {
-		String emojifiedText = emojify(text);
+		return shortCodify(text, false);
+	}
+
+	public static String shortCodify(String text, boolean ignoreEmoticon) {
+		String emojifiedText = emojify(text, ignoreEmoticon);
 
 		// TODO - this approach is ugly, need to find an optimal way to replace
 		// the emojis

--- a/src/test/java/emoji4j/EmojiTest.java
+++ b/src/test/java/emoji4j/EmojiTest.java
@@ -162,6 +162,15 @@ public class EmojiTest {
 	}
 
 	@Test
+	public void shouldIgnoreEmoticonsIfSpecified() {
+		String text = "Payment 123 (Tax) 🤑";
+		String actual = EmojiUtils.shortCodify(text, true);
+
+		assertThat(actual)
+				.isEqualTo("Payment 123 (Tax) :money_mouth_face:");
+	}
+
+	@Test
 	public void testShortCodifyFromHtmlEntities() {
 		String text = "A &#128049;, &#128054; and a &#128045; became friends. For &#128054;'s birthday party, they all had &#127828;s, &#127839;s, &#127850;s and &#127856;.";
 		assertThat(EmojiUtils.shortCodify(text))


### PR DESCRIPTION
Strings such as `Payment 123 (Tax) 🤑` contain the string `x)` but this should not match an emoticon